### PR TITLE
Make it "php-parser" compatible

### DIFF
--- a/tools/console.php
+++ b/tools/console.php
@@ -1,4 +1,4 @@
-#!/usr/bin/php
+#!/usr/bin/env php
 <?php
 
 /*


### PR DESCRIPTION
I meet this error when I use tools depending on [PHP-Parser](https://github.com/nikic/PHP-Parser) : 
```
Unhandled error
Symfony\Component\Debug\Exception\FatalErrorException: Namespace declaration statement has to be the very first statement or after any declare call in the script
Location
vendor/teknoo/sellsy-client/tools/console.php:24 - [main]
```

Hashbang has to be `#!/usr/bin/env php`, not `#!/usr/bin/php` and for me it's a better syntax : https://github.com/nikic/PHP-Parser/commit/c4bbc8e236a1f21b2b17cfbf3d46aa6ece69b9f7